### PR TITLE
Fix automation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## 📖  About Me
 - <p align="left"> I'm currently working as a Data Engineer. I graduated from Fırat University, Department of Software Engineering </p>
 - <p align="leftleft"> I’m currently working on Machine Learning, Deep Learning, Data Engineer,Data Analytics,CI/Cd systems  </p>
-- <p align="left"> I’m currently learning Keras,Docker,AWS, Django,Automaiton Test and Load Test New Technology</a></p>
+- <p align="left"> I’m currently learning Keras,Docker,AWS, Django,Automation Test and Load Test New Technology</a></p>
  
  
 


### PR DESCRIPTION
## Summary
- fix an automation spelling error in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847f3f51e7c832aa47777b8133355e3