### PR TITLE
Add README linter test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint README
+
+on:
+  push:
+    paths:
+      - README.md
+      - tests/**
+      - .github/workflows/**
+  pull_request:
+    paths:
+      - README.md
+      - tests/**
+      - .github/workflows/**
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install mdformat
+        run: pip install mdformat
+      - name: Run linter
+        run: ./tests/lint_readme.sh

--- a/tests/lint_readme.sh
+++ b/tests/lint_readme.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Lint README.md using mdformat
+set -e
+mdformat --check README.md


### PR DESCRIPTION
## Summary
- ensure README formatting is checked
- run linter in CI using GitHub Actions

## Testing
- `./tests/lint_readme.sh` *(fails: mdformat: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f3f49bcc832a836ce4d354f89844