### PR TITLE
Fix HTML closing tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,6 @@
    <img width="48%" src="https://github-readme-stats.vercel.app/api?username=akarakus27&show_icons=true&theme=tokyonight" />
    <img width="48%" src="https://github-readme-streak-stats.herokuapp.com/?user=akarakus27&theme=tokyonight" />
    <img width="50%" src="https://github-readme-stats.vercel.app/api/top-langs/?username=akarakus27&layout=compact&hide=html"  alt="akarakus27" />
-</p
+</p>
 
  


### PR DESCRIPTION
## Summary
- close GitHub stats paragraph tag in `README.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6847f3f271f4832a9b5ed4f8556dbb0b